### PR TITLE
Allow StarknetKeypairWallet to bind to an existing account address

### DIFF
--- a/src/starknet/wallet/accounts/StarknetKeypairWallet.ts
+++ b/src/starknet/wallet/accounts/StarknetKeypairWallet.ts
@@ -5,43 +5,89 @@ import {Buffer} from "buffer";
 const OZaccountClassHash = '0x00261c293c8084cd79086214176b33e5911677cec55104fddc8d25b0b736dcad';
 
 /**
- * Keypair-based wallet implementation using OpenZeppelin Account
+ * Keypair-based wallet implementation wrapping a starknet.js {@link Account}.
+ *
+ * A Starknet account's address is a function of its account contract class hash, so the
+ * same private key maps to a different address for each wallet vendor (Argent, Braavos,
+ * OpenZeppelin, ...). Therefore:
+ *
+ * - Pass an existing account `address` to bind the wallet to the account the key actually
+ *   controls, regardless of its class hash. The wallet uses it as-is and never attempts a
+ *   self-deployment. This is the correct option for existing Argent/Braavos/OpenZeppelin
+ *   accounts.
+ * - Omit `address` to derive and self-deploy a fresh OpenZeppelin account from the key
+ *   (see {@link newOpenZeppelinAccount}). Only use this for keys generated for the SDK, as
+ *   the derived OpenZeppelin address will not match an existing Argent/Braavos account.
  *
  * @category Wallets
  */
 export class StarknetKeypairWallet extends Account {
 
     public readonly publicKey: string;
+    private readonly deploymentData: DeployAccountContractPayload | null;
 
-    constructor(provider: Provider, privateKey: string) {
+    /**
+     * @param provider Starknet provider
+     * @param privateKey Account owner's private key
+     * @param address Optional address of an existing account controlled by the key. When
+     *  provided, the wallet binds to this account as-is (no OpenZeppelin derivation and no
+     *  self-deployment). When omitted, a fresh OpenZeppelin account address is derived from
+     *  the key and deployed on first use.
+     */
+    constructor(provider: Provider, privateKey: string, address?: string) {
         const publicKey = ec.starkCurve.getStarkKey(toHex(privateKey));
-        // Calculate future address of the account
-        const OZaccountConstructorCallData = CallData.compile({ publicKey });
-        const OZcontractAddress = hash.calculateContractAddressFromHash(
-            publicKey,
-            OZaccountClassHash,
-            OZaccountConstructorCallData,
-            0
-        );
+
+        let accountAddress: string;
+        let deploymentData: DeployAccountContractPayload | null = null;
+        if(address != null) {
+            //Bind to the existing account the key controls, regardless of its class hash
+            accountAddress = address;
+        } else {
+            //Derive a fresh OpenZeppelin account address & prepare its deployment payload
+            const OZaccountConstructorCallData = CallData.compile({ publicKey });
+            accountAddress = hash.calculateContractAddressFromHash(
+                publicKey,
+                OZaccountClassHash,
+                OZaccountConstructorCallData,
+                0
+            );
+            deploymentData = {
+                classHash: OZaccountClassHash,
+                constructorCalldata: OZaccountConstructorCallData,
+                addressSalt: publicKey,
+                contractAddress: accountAddress
+            };
+        }
+
         super({
             provider,
-            address: OZcontractAddress,
+            address: accountAddress,
             signer: privateKey,
             cairoVersion: "1"
         });
         this.publicKey = publicKey;
+        this.deploymentData = deploymentData;
     }
 
     /**
      * @inheritDoc
+     *
+     * Returns the OpenZeppelin account deployment payload when this wallet derived its own
+     * address, or null when an explicit (already-deployed) account address was provided.
      */
-    public getDeploymentData(): DeployAccountContractPayload {
-        return {
-            classHash: OZaccountClassHash,
-            constructorCalldata: CallData.compile({ publicKey: this.publicKey }),
-            addressSalt: this.publicKey,
-            contractAddress: this.address
-        }
+    public getDeploymentData(): DeployAccountContractPayload | null {
+        return this.deploymentData;
+    }
+
+    /**
+     * Constructs a wallet that derives and self-deploys a fresh OpenZeppelin account from
+     * the provided private key. Equivalent to omitting the `address` constructor argument.
+     *
+     * @param provider Starknet provider
+     * @param privateKey Account owner's private key
+     */
+    public static newOpenZeppelinAccount(provider: Provider, privateKey: string): StarknetKeypairWallet {
+        return new StarknetKeypairWallet(provider, privateKey);
     }
 
     /**


### PR DESCRIPTION
Fixes #22

## Problem
`StarknetKeypairWallet` always derived its account address from a single hardcoded OpenZeppelin account class hash. On Starknet an account's address is a function of its class hash, so a private key controlling an existing **Argent/Braavos** (or any non-OZ) account resolves to a *different*, undeployed address. Any swap that spends on the Starknet side (Smart-chain → BTC, or moving received tokens) then targets an empty account, and `swap.execute()` fails with a spurious `DEPLOY_ACCOUNT` and:

```
Account validation failed: "Resources bounds (...) exceed balance (0)."
```

## Change
Add an optional `address` argument to the constructor:

- **When provided** — the wallet binds to that account as-is, regardless of its class hash (Argent/Braavos/OpenZeppelin/…), and performs **no** self-deployment. `getDeploymentData()` returns `null`, so the SDK no longer prepends a bogus `DEPLOY_ACCOUNT`.
- **When omitted** — behaviour is **unchanged**: a fresh OpenZeppelin account address is derived from the key and self-deployed on first use.

Also adds `StarknetKeypairWallet.newOpenZeppelinAccount(provider, key)` as an explicit alias for the derive-and-deploy path.

## Backwards compatibility
Non-breaking. Existing `new StarknetKeypairWallet(provider, key)` callers keep the exact prior behaviour (OZ derivation + self-deploy). The only signature change is a new **optional** trailing parameter, and `getDeploymentData()`'s return type widens to `... | null`.

## Verification
- Type-checks clean under both `build:ts4` (TypeScript 4.9) and `build:ts5` (TypeScript 5.3).
- Runtime-checked against the built code: with an explicit `address`, `getAddress()` binds to it and `getDeploymentData()` is `null`; without it, the OZ address is derived and `getDeploymentData()` is non-null; the factory matches the no-address path.

## Note on approach
This is the non-breaking variant (optional `address`, OZ derivation kept as the default fallback). If you'd prefer the stricter version discussed in #22 — make `address` required and drop the implicit OZ derivation entirely — happy to adjust.